### PR TITLE
KAN-19 Fix bug when unselecting does not make correct

### DIFF
--- a/src/components/SingleNotePickerForm.tsx
+++ b/src/components/SingleNotePickerForm.tsx
@@ -54,7 +54,7 @@ function SingleNotePickerForm({ correctNote, onSubmit, isAnswerCorrect }: Props)
                     color="primary"
                     aria-labelledby="pitch-selector-label"
                     value={selectedPitch}
-                    onChange={(_, value) => setSelectedPitch(value)}
+                    onChange={(_, val) => setSelectedPitch(val ?? '')}
                     exclusive
                     size="large"
                     sx={{ height: 42, alignSelf: 'center' }}
@@ -66,7 +66,7 @@ function SingleNotePickerForm({ correctNote, onSubmit, isAnswerCorrect }: Props)
                     color='secondary'
                     aria-labelledby="octave-selector-label"
                     value={selectedOctave}
-                    onChange={(_, val) => setSelectedOctave(val)}
+                    onChange={(_, val) => setSelectedOctave(val ?? '')}
                     exclusive
                     size="large"
                     sx={{ height: 42, alignSelf: 'center' }}>


### PR DESCRIPTION
Address the issue where unselecting the octave makes the check always wrong.

The underlying issue is Material UI ToggleButtonGroup passes a null when the user unselects.
We check correctness by simply concatenating strings, so if the octave is null and the pitch is 'g', we'll compare 'gnull' to the correct note 'g'.

In this fix, we add fallback: if the value is null, set it to an empty string instead of null.