### PR TITLE
KAN-20 Pass down object as correct note instead of string

### DIFF
--- a/src/components/NoteToPitchTestSection.tsx
+++ b/src/components/NoteToPitchTestSection.tsx
@@ -72,7 +72,7 @@ function NoteToPitchTestSection({ goToMainPage }: Props) {
 
   return <>
     <SingleNoteSheet xmlDoc={xmlDoc} />
-    <SingleNotePickerForm correctNote={note.pitch + note.octave} isAnswerCorrect={isCorrect} onSubmit={handleSubmit} />
+    <SingleNotePickerForm correctNote={note} isAnswerCorrect={isCorrect} onSubmit={handleSubmit} />
     <Box marginTop={1}>
       <Button color='success' onClick={() => onPlayClick(note)}><PlayArrow /></Button>
     </Box>

--- a/src/components/SingleNotePickerForm.tsx
+++ b/src/components/SingleNotePickerForm.tsx
@@ -1,14 +1,15 @@
 import { Box, Button, FormControl, FormLabel, ToggleButton, ToggleButtonGroup, Typography } from "@mui/material";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { UserPreferencesContext } from "./UserPreferencesContextProvider";
-import { convertScientificToHelmholtz } from "../utils/pitchNotationUtils";
+import { convertNoteDefinitionToNote, convertScientificToHelmholtz } from "../utils/pitchNotationUtils";
+import { NoteDefinition } from "../utils/musicXMLUtils";
 
 const PITCHS = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
 const LOWER_CASE_PITCHS = PITCHS.map(c => c.toLowerCase());
 const OCTAVES = ['1', '2', '3', '4', '5', '6'];
 
 type Props = {
-    correctNote: string,
+    correctNote: NoteDefinition,
     onSubmit: (isCorrect: boolean) => void,
     isAnswerCorrect: boolean | null
 };
@@ -23,7 +24,9 @@ function SingleNotePickerForm({ correctNote, onSubmit, isAnswerCorrect }: Props)
     const { noteToPitchTestFormat } = useContext(UserPreferencesContext);
 
     const convertedCorrectNote = useMemo(() => {
-        return noteToPitchTestFormat == 'Helmholtz' ? convertScientificToHelmholtz(correctNote) : correctNote;
+        return noteToPitchTestFormat == 'Helmholtz' ?
+            convertScientificToHelmholtz(correctNote) :
+            convertNoteDefinitionToNote(correctNote);
     }, [correctNote]);
 
     const checkNote = () => {

--- a/src/utils/pitchNotationUtils.ts
+++ b/src/utils/pitchNotationUtils.ts
@@ -1,17 +1,20 @@
-export function convertScientificToHelmholtz(scientificPitch: string): string {
-    if (scientificPitch.length != 2) {
-        throw Error(`pitch not supported ${scientificPitch}`);
-    }
+import { ScientificNote } from "../types/NoteType";
+import { NoteDefinition } from "./musicXMLUtils";
 
-    const pitchNote = scientificPitch[0];
-    const octave = parseInt(scientificPitch[1]);
+export function convertScientificToHelmholtz(scientificPitch: NoteDefinition): string {
+    const { pitch, octave: octaveStr } = scientificPitch;
+    const octave = Number(octaveStr);
     if (octave > 3) {
-        return `${pitchNote.toLowerCase()}${octave - 3}`
+        return `${pitch.toLowerCase()}${octave - 3}`
     } else if (octave == 3) {
-        return `${pitchNote.toLowerCase()}`;
+        return `${pitch.toLowerCase()}`;
     } else if (octave == 2) {
-        return pitchNote;
+        return pitch;
     } else {
-        return `${pitchNote}${2 - octave}`;
+        return `${pitch}${2 - octave}`;
     }
+}
+
+export function convertNoteDefinitionToNote(noteDefinition: NoteDefinition): ScientificNote {
+    return `${noteDefinition.pitch}${noteDefinition.octave}`;
 }


### PR DESCRIPTION
The root cause of [issue](https://github.com/wangtjwork/3_mins_musical_societies/issues/3) is that we pass down a string correctNote to the form, and the form use a useEffect to nuke all states if correctNote changes.
If the previous note is the same as the next one, the generated string is the same. As string is a JS primitive type, React compares correctNote by value, aka. the `useEffect` hook will not run.

The fix is to pass down object instead of string, and making sure a new object is generated instead of re-using old ones. Then useEffect will run even if previous & current is the same note.